### PR TITLE
Remove the styling to auto capitalize header

### DIFF
--- a/frontend/src/Styles/TopBarSettings.module.css
+++ b/frontend/src/Styles/TopBarSettings.module.css
@@ -6,13 +6,11 @@
 .header {
     grid-area: Header;
     justify-self: center;
-    text-transform: capitalize;
 }
 
 .settingsButton {
     grid-area: Settings;
     justify-self: end;
-
 }
 
 .container {


### PR DESCRIPTION
# Description
This PR fixes #221 

Fix a bug where the first character of room code is automatically capitalized.

# Demo
Before: 
![image](https://user-images.githubusercontent.com/29315719/111892335-67a00a80-8a5f-11eb-98ea-528666d17173.png)


After: 
![image](https://user-images.githubusercontent.com/29315719/111892360-a1711100-8a5f-11eb-9fb8-bf40d6621e36.png)



# Type of change:
(Delete the ones that are not relevant)
* Bug fix (Non-breaking change which fixes a bug)

# Checklist ✅
* Have you merged main into your branch?
* Have you tested your changes to ensure it works as expected and does not break existing functionality?
* If applicable, please ensure sufficient tests are added that is related to the changes.
* Please ensure this PR has a `label`, is linked to an `issue` and is related to a `project`
* If new documentation is required for this change, have you created a new documentation issue that describes the documentation needed? 