### PR TITLE
Remove prettier from ESLint check

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -15,7 +15,6 @@
     },
     "plugins": ["react", "prettier"],
     "rules": {
-        "prettier/prettier": "error",
         "no-unused-vars": "warn",
         "no-console": "warn",
         "no-await-in-loop": "off",


### PR DESCRIPTION
# Description
This PR fixes #125 

ESLint uses the rule `"prettier/prettier": "error"` . However the rule is stored at the root folder, which is not part of the build artifact on Heroku. This casues a problem when heroku tries to build, since it can't find the rule, it uses the default prettier config which contains two spaces for a tab, and this isn't our coding standard and hence throws a build error, therefore the CD app is broken.  

Options are as below:
* Investigate options on heroku to clone the entire project and build from a folder (Non-trivial)
* Move prettier config and introduce non universal prettier config for frontend and backend
* Remove prettier from ESLint check

Reason that I picked the third option is because it's the easiest way to resolve this problem and introduce the least amount of inconsistency. The other two options may take longer and I don't want to introduce more code level changes on the last day.

# Demo
Before: Application Error on deployed website

After: Mafia game on deployed website 

# Type of change:
* Bug fix (Non-breaking change which fixes a bug)

# Checklist ✅
* Have you merged main into your branch?
* Have you tested your changes to ensure it works as expected and does not break existing functionality?
* If applicable, please ensure sufficient tests are added that is related to the changes.
* Please ensure this PR has a `label`, is linked to an `issue` and is related to a `project`
* If new documentation is required for this change, have you created a new documentation issue that describes the documentation needed? 