### PR TITLE
Fixed bug with jesters winning when killed by mafia

### DIFF
--- a/backend/Events/GameStateEvents/NightStateChangeEvents.js
+++ b/backend/Events/GameStateEvents/NightStateChangeEvents.js
@@ -1,5 +1,6 @@
 const config = require('../../config.json');
 const GameStateEnum = require('../../domain/Enum/GameStateEnum');
+const PlayerStatus = require('../../domain/Enum/PlayerStatus');
 
 const NightStartDTO = require('../../domain/DTO/response/NightStartDTO');
 const NightEndDTO = require('../../domain/DTO/response/NightEndDTO');
@@ -41,7 +42,7 @@ function endNight(io, socket, mafiaGame) {
     const playerKilled = room.voteHandler.getMafiaVotedPlayer();
 
     if (playerKilled) {
-        room.getPlayerByNickname(playerKilled).isAlive = false;
+        room.getPlayerByNickname(playerKilled).status = PlayerStatus.KILLED_BY_MAFIA;
     }
 
     const winningRole = room.getWinningRole();

--- a/backend/Events/GameStateEvents/TrialStateChangeEvents.js
+++ b/backend/Events/GameStateEvents/TrialStateChangeEvents.js
@@ -1,5 +1,6 @@
 const config = require('../../config.json');
 const GameStateEnum = require('../../domain/Enum/GameStateEnum');
+const PlayerStatus = require('../../domain/Enum/PlayerStatus');
 
 const TrialStartDTO = require('../../domain/DTO/response/DayStartDTO');
 const TrialEndDTO = require('../../domain/DTO/response/TrialEndDTO');
@@ -41,7 +42,7 @@ function endTrial(io, socket, mafiaGame) {
     const playerChosen = room.voteHandler.getTrialVotedPlayer();
 
     if (playerChosen && playerChosen !== 'abstain Vote') {
-        room.getPlayerByNickname(playerChosen).isAlive = false;
+        room.getPlayerByNickname(playerChosen).status = PlayerStatus.KILLED_BY_TOWN;
     }
 
     const winningRole = room.getWinningRole();

--- a/backend/domain/Enum/PlayerStatus.js
+++ b/backend/domain/Enum/PlayerStatus.js
@@ -1,0 +1,12 @@
+/**
+ * Enum for player status.
+ * Can be developed into classes if functionality is required.
+ */
+const PlayerStatus = {
+    ALIVE: 'alive',
+    KILLED_BY_MAFIA: 'killed_by_mafia',
+    KILLED_BY_TOWN: 'killed_by_town',
+};
+Object.freeze(PlayerStatus);
+
+module.exports = PlayerStatus;

--- a/backend/domain/Player.js
+++ b/backend/domain/Player.js
@@ -1,3 +1,5 @@
+const PlayerStatus = require('./Enum/PlayerStatus');
+
 /**
  * Represents a player in a game of Mafia.
  * A player is part of a room, and they are tied to a socket that is connected to the server.
@@ -9,7 +11,7 @@ class Player {
         this.roomID = roomID;
         this.nickname = nickname;
         this.role = role;
-        this.isAlive = true;
+        this.status = PlayerStatus.ALIVE;
         this.isHost = isHost;
     }
 
@@ -18,7 +20,7 @@ class Player {
      */
     resetPlayer() {
         this.role = null;
-        this.isAlive = true;
+        this.status = PlayerStatus.ALIVE;
     }
 }
 

--- a/backend/domain/Room.js
+++ b/backend/domain/Room.js
@@ -113,8 +113,9 @@ class Room {
         ].filter((player) => player.status === PlayerStatus.ALIVE).length;
 
         // Jesters win if any one of them is killed in a trial
-        const jesters = this.getPlayersByRole(roles.JESTER);
-        const jestersWin = jesters.some((jester) => jester.status === PlayerStatus.KILLED_BY_TOWN);
+        const jestersWin = this.getPlayersByRole(roles.JESTER).some(
+            (jester) => jester.status === PlayerStatus.KILLED_BY_TOWN
+        );
 
         if (numOfMafiaAlive === 0) {
             return roles.CIVILIAN;

--- a/backend/domain/Room.js
+++ b/backend/domain/Room.js
@@ -1,4 +1,5 @@
 const GameStateEnum = require('./Enum/GameStateEnum');
+const PlayerStatus = require('./Enum/PlayerStatus');
 const VoteHandler = require('./VoteHandler');
 const roles = require('./Enum/Role');
 
@@ -100,21 +101,28 @@ class Room {
      * @returns The winning role, or null if no role has won.
      */
     getWinningRole() {
-        const numOfMafiaAlive = this.getPlayersByRole(roles.MAFIA).filter((player) => player.isAlive).length;
-        const numOfJesterAlive = this.getPlayersByRole(roles.JESTER).filter((player) => player.isAlive).length;
+        const numOfMafiaAlive = this.getPlayersByRole(roles.MAFIA).filter(
+            (player) => player.status === PlayerStatus.ALIVE
+        ).length;
+
         const numOfCiviliansAlive = [
             ...this.getPlayersByRole(roles.CIVILIAN),
             ...this.getPlayersByRole(roles.MEDIC),
             ...this.getPlayersByRole(roles.DETECTIVE),
-        ].filter((player) => player.isAlive).length;
+            ...this.getPlayersByRole(roles.JESTER),
+        ].filter((player) => player.status === PlayerStatus.ALIVE).length;
+
+        // Jesters win if any one of them is killed in a trial
+        const jesters = this.getPlayersByRole(roles.JESTER);
+        const jestersWin = jesters.some((jester) => jester.status === PlayerStatus.KILLED_BY_TOWN);
 
         if (numOfMafiaAlive === 0) {
             return roles.CIVILIAN;
         }
-        if (numOfMafiaAlive === numOfCiviliansAlive + numOfJesterAlive) {
+        if (numOfMafiaAlive >= numOfCiviliansAlive) {
             return roles.MAFIA;
         }
-        if (numOfJesterAlive === 0) {
+        if (jestersWin) {
             return roles.JESTER;
         }
 

--- a/backend/test/unit/DomainModel.unit.test.js
+++ b/backend/test/unit/DomainModel.unit.test.js
@@ -1,5 +1,7 @@
 const Player = require('../../domain/Player');
 const Room = require('../../domain/Room');
+const PlayerStatus = require('../../domain/Enum/PlayerStatus');
+const Role = require('../../domain/Enum/Role');
 
 describe('Domain Model tests', () => {
     test('room domain max model object', (done) => {
@@ -34,5 +36,80 @@ describe('Domain Model tests', () => {
         if (room.players.length === 1) {
             done();
         }
+    });
+});
+
+describe('winning role tests', () => {
+    let room;
+    let jester;
+    let civilian1;
+    let civilian2;
+    let mafia;
+    let medic;
+    let detective;
+
+    beforeEach(() => {
+        jester = new Player('00001', 'room1', 'nickname1', Role.JESTER, true);
+        civilian1 = new Player('00002', 'room1', 'nickname2', Role.CIVILIAN, false);
+        civilian2 = new Player('00003', 'room1', 'nickname3', Role.CIVILIAN, false);
+        mafia = new Player('00004', 'room1', 'nickname4', Role.MAFIA, false);
+        medic = new Player('00005', 'room1', 'nickname5', Role.MEDIC, false);
+        detective = new Player('00006', 'room1', 'nickname6', Role.DETECTIVE, false);
+
+        room = new Room();
+        room.addPlayer(jester);
+        room.addPlayer(civilian1);
+        room.addPlayer(civilian2);
+        room.addPlayer(mafia);
+        room.addPlayer(medic);
+        room.addPlayer(detective);
+    });
+
+    test('jester wins by getting killed in a trial', (done) => {
+        expect(jester.status).toBe(PlayerStatus.ALIVE);
+
+        let winningRole = room.getWinningRole();
+        expect(winningRole).toBeNull();
+
+        jester.status = PlayerStatus.KILLED_BY_TOWN;
+        winningRole = room.getWinningRole();
+        expect(winningRole).toBe(Role.JESTER);
+
+        done();
+    });
+
+    test('civilians win by eliminating mafia', (done) => {
+        mafia.status = PlayerStatus.KILLED_BY_TOWN;
+        const winningRole = room.getWinningRole();
+        expect(winningRole).toBe(Role.CIVILIAN);
+
+        done();
+    });
+
+    test('mafia wins by eliminating everyone except one', (done) => {
+        // Two good players still alive - game should not be over yet.
+        civilian1.status = PlayerStatus.KILLED_BY_MAFIA;
+        civilian2.status = PlayerStatus.KILLED_BY_TOWN;
+        medic.status = PlayerStatus.KILLED_BY_MAFIA;
+
+        let winningRole = room.getWinningRole();
+        expect(winningRole).toBeNull();
+
+        // Mafia kills detective and only jester remians - mafia should win.
+        detective.status = PlayerStatus.KILLED_BY_MAFIA;
+
+        winningRole = room.getWinningRole();
+        expect(winningRole).toBe(Role.MAFIA);
+
+        done();
+    });
+
+    test('jester does not win if killed by mafia', (done) => {
+        jester.status = PlayerStatus.KILLED_BY_MAFIA;
+
+        let winningRole = room.getWinningRole();
+        expect(winningRole).toBeNull();
+
+        done();
     });
 });


### PR DESCRIPTION
# Description
This PR fixes #201

- Added an enum for player status. The `PlayerStatus` enum contains values of `ALIVE`, `KILLED_BY_MAFIA` and `KILLED_BY_TOWN`. This was suggested by @seif-y in #201. This solution makes it more flexible when adding new roles in the future.
- Replaced `isAlive` with `status` in the Player class, where `status` uses the `PlayerStatus` enum.
- Now checks whether the jester was killed by mafia or in trial. Jesters will no longer win when killed by a mafia. Jesters only win when any jester is killed in a trial.
- Added unit tests for winning role

# Demo
N/A

# Type of change:
* Bug fix (Non-breaking change which fixes a bug)

# Checklist:
* Have you merged main into your branch?
* Have you tested your changes to ensure it works as expected and does not break existing functionality?
* If applicable, please ensure sufficient tests are added that is related to the changes.
* Please ensure this PR has a `label`, is linked to an `issue` and is related to a `project`
* If new documentation is required for this change, have you created a new documentation issue that describes the documentation needed? 