### PR TITLE
Add host player to room in MafiaGameMock

### DIFF
--- a/backend/domain/Room.js
+++ b/backend/domain/Room.js
@@ -39,7 +39,6 @@ class Room {
                 returnedPlayer = player;
             }
         });
-
         return returnedPlayer;
     }
 

--- a/backend/test/mocks/MafiaGameMock.js
+++ b/backend/test/mocks/MafiaGameMock.js
@@ -30,6 +30,7 @@ function createMafiaGameWithOnePlayerMock(port) {
     const roomID = mafiaGame.newGame();
     mafiaGame.gameRoomsDict[roomID] = new Room();
     const hostPlayer = new Player(null, roomID, 'mafiaPlayer', 'mafia', true);
+    addPlayer(hostPlayer, roomID);
 
     io.on('connection', (socket) => {
         loadLobbyEvents(io, socket, mafiaGame);
@@ -62,6 +63,11 @@ function addPlayers(players, roomID) {
     for (let player of players) {
         room.addPlayer(player);
     }
+}
+
+function getHostPlayer(roomID) {
+    const room = mafiaGame.gameRoomsDict[roomID];
+    return room.players[0];
 }
 
 function addMafiaVote(voter, votedFor, roomID) {
@@ -101,12 +107,16 @@ function resetRoom(roomID) {
     room.players = [];
     room.host = null;
     room.voteHandler.resetVotes();
+
+    const hostPlayer = new Player(null, roomID, 'mafiaPlayer', 'mafia', true);
+    addPlayer(hostPlayer, roomID);
 }
 
 module.exports = {
     createMafiaGameWithOnePlayerMock,
     addPlayer,
     addPlayers,
+    getHostPlayer,
     addMafiaVote,
     addDayVote,
     addTrialVote,

--- a/backend/test/unit/DayStateChangeEvents.unit.test.js
+++ b/backend/test/unit/DayStateChangeEvents.unit.test.js
@@ -47,11 +47,13 @@ describe('start-day unit tests', () => {
     test('start-day successful call, someone is put on trial', (done) => {
         const mafiaPlayer = new Player(null, null, 'a', roles.MAFIA, true);
         const civilianPlayer = new Player(null, null, 'b', roles.CIVILIAN, true);
+        const hostPlayer = MafiaGameMock.getHostPlayer(roomElements.roomID); // host is mafia
 
         MafiaGameMock.addPlayer(mafiaPlayer, roomElements.roomID);
         MafiaGameMock.addPlayer(civilianPlayer, roomElements.roomID);
 
         MafiaGameMock.addDayVote(mafiaPlayer, civilianPlayer, roomElements.roomID); // Mafia votes for civilian
+        MafiaGameMock.addDayVote(hostPlayer, civilianPlayer, roomElements.roomID); // host votes for civilian
 
         // Registering mock event handlers that would respond to emits emitted by the backend
         clientSocket.on('day-start', (dayStartDTO) => {

--- a/backend/test/unit/NightStateChangeEvents.unit.test.js
+++ b/backend/test/unit/NightStateChangeEvents.unit.test.js
@@ -47,11 +47,13 @@ describe('start-night unit tests', () => {
     test('start-night successful call, someone is killed', (done) => {
         const playerA = new Player(null, null, 'a', roles.MAFIA, true);
         const playerB = new Player(null, null, 'a', roles.MAFIA, true);
+        const hostPlayer = MafiaGameMock.getHostPlayer(roomElements.roomID); // host is mafia
 
         MafiaGameMock.addPlayer(playerA, roomElements.roomID);
         MafiaGameMock.addPlayer(playerB, roomElements.roomID);
 
         MafiaGameMock.addMafiaVote(playerA, playerB, roomElements.roomID);
+        MafiaGameMock.addMafiaVote(hostPlayer, playerB, roomElements.roomID);
 
         // Register mock event handlers for the events that the backend emits - assertions for the DTOs
         clientSocket.on('night-start', (nightStartDTO) => {

--- a/backend/test/unit/TrialStateChangeEvents.unit.test.js
+++ b/backend/test/unit/TrialStateChangeEvents.unit.test.js
@@ -36,10 +36,13 @@ describe('trial-start unit tests', () => {
         const playerA = new Player(null, null, 'a', roles.MAFIA, true);
         const playerB = new Player(null, null, 'b', roles.JESTER, true);
         const playerC = new Player(null, null, 'c', roles.CIVILIAN, true);
+        const playerD = new Player(null, null, 'd', roles.CIVILIAN, true);
 
+        // total 5 players: mock initialised with host player which is mafia
         MafiaGameMock.addPlayer(playerA, roomElements.roomID);
         MafiaGameMock.addPlayer(playerB, roomElements.roomID);
         MafiaGameMock.addPlayer(playerC, roomElements.roomID);
+        MafiaGameMock.addPlayer(playerD, roomElements.roomID);
 
         // Register mock event handlers for the events that the backend emits - assertions for the DTOs
         clientSocket.on('trial-start', (trialStartDTO) => {
@@ -60,13 +63,16 @@ describe('trial-start unit tests', () => {
         const playerB = new Player(null, null, 'b', roles.CIVILIAN, true);
         const playerC = new Player(null, null, 'c', roles.JESTER, true);
         const playerD = new Player(null, null, 'd', roles.CIVILIAN, true);
+        const playerE = new Player(null, null, 'e', roles.CIVILIAN, true);
+        const hostPlayer = MafiaGameMock.getHostPlayer(roomElements.roomID); // host is mafia
 
         MafiaGameMock.addPlayer(playerA, roomElements.roomID);
         MafiaGameMock.addPlayer(playerB, roomElements.roomID);
         MafiaGameMock.addPlayer(playerC, roomElements.roomID);
         MafiaGameMock.addPlayer(playerD, roomElements.roomID);
+        MafiaGameMock.addPlayer(playerE, roomElements.roomID);
 
-        MafiaGameMock.addTrialVote(playerA, playerD, roomElements.roomID); // Vote to kill off a civilian
+        MafiaGameMock.addTrialVote(hostPlayer, playerD, roomElements.roomID); // Vote to kill off a civilian
 
         // Register mock event handlers for the events that the backend emits - assertions for the DTOs
         clientSocket.on('trial-start', (trialStartDTO) => {
@@ -86,12 +92,15 @@ describe('trial-start unit tests', () => {
         const playerA = new Player(null, null, 'a', roles.MAFIA, true);
         const playerB = new Player(null, null, 'b', roles.CIVILIAN, true);
         const playerC = new Player(null, null, 'c', roles.CIVILIAN, true);
+        const playerD = new Player(null, null, 'd', roles.CIVILIAN, true);
+        const hostPlayer = MafiaGameMock.getHostPlayer(roomElements.roomID); // host is mafia
 
         MafiaGameMock.addPlayer(playerA, roomElements.roomID);
         MafiaGameMock.addPlayer(playerB, roomElements.roomID);
         MafiaGameMock.addPlayer(playerC, roomElements.roomID);
+        MafiaGameMock.addPlayer(playerD, roomElements.roomID);
 
-        MafiaGameMock.addTrialVote(playerB, playerC, roomElements.roomID); // Vote to kill a civilian
+        MafiaGameMock.addTrialVote(hostPlayer, playerC, roomElements.roomID); // Vote to kill a civilian
 
         // Register mock event handlers for the events that the backend emits - assertions for the DTOs
         clientSocket.on('trial-start', (trialStartDTO) => {

--- a/backend/test/unit/VotingEvents.unit.test.js
+++ b/backend/test/unit/VotingEvents.unit.test.js
@@ -81,7 +81,6 @@ describe('night time voting event tests', () => {
             new Player(null, roomElements.roomID, 'notMafia', RoleEnum.MAFIA, false),
             new Player(null, roomElements.roomID, 'Doctor', RoleEnum.MEDIC, true),
             new Player(null, roomElements.roomID, 'Sherlock', RoleEnum.DETECTIVE, false),
-            new Player(null, roomElements.roomID, 'Dude', RoleEnum.CIVILIAN, true),
         ];
         MafiaGameMock.addPlayers(players, roomElements.roomID);
     });
@@ -90,7 +89,7 @@ describe('night time voting event tests', () => {
         // Listen for night end to check that player has been killed.
         clientSocket.on('night-end', (nightEndDTO) => {
             try {
-                expect(nightEndDTO.playerKilled).toEqual('Dude');
+                expect(nightEndDTO.playerKilled).toEqual('P0');
                 done();
             } catch (error) {
                 done.fail(error);
@@ -99,7 +98,9 @@ describe('night time voting event tests', () => {
 
         // Switch to mafia player to make vote
         MafiaGameMock.switchPlayer('notMafia', roomElements.roomID);
-        clientSocket.emit('mafia-vote', new NightTimeVoteDTO('Dude'));
+        clientSocket.emit('mafia-vote', new NightTimeVoteDTO('P0'));
+        MafiaGameMock.switchPlayer('mafiaPlayer', roomElements.roomID);
+        clientSocket.emit('mafia-vote', new NightTimeVoteDTO('P0'));
 
         clientSocket.emit('start-night');
     });
@@ -117,11 +118,13 @@ describe('night time voting event tests', () => {
 
         // Switch to mafia player to make vote
         MafiaGameMock.switchPlayer('notMafia', roomElements.roomID);
-        clientSocket.emit('mafia-vote', new NightTimeVoteDTO('Dude'));
+        clientSocket.emit('mafia-vote', new NightTimeVoteDTO('P0'));
+        MafiaGameMock.switchPlayer('mafiaPlayer', roomElements.roomID);
+        clientSocket.emit('mafia-vote', new NightTimeVoteDTO('P0'));
 
         // Switch to medic to save same player as mafia player
         MafiaGameMock.switchPlayer('Doctor', roomElements.roomID);
-        clientSocket.emit('medic-vote', new NightTimeVoteDTO('Dude'));
+        clientSocket.emit('medic-vote', new NightTimeVoteDTO('P0'));
 
         clientSocket.emit('start-night');
     });


### PR DESCRIPTION
# Description
This PR fixes #275 

Add the hostplayer in `MafiaGameMock` to the `room.players` array and modify the tests so they behave as expected and pass.

# Demo
N/A


# Type of change:
* Bug fix (Non-breaking change which fixes a bug)