### PR TITLE
Change abstain variable name to noConfidence when calculating vote results

### DIFF
--- a/backend/.eslintrc.json
+++ b/backend/.eslintrc.json
@@ -9,7 +9,6 @@
         "jasmine": true
     },
     "rules": {
-        "dot-notation": "off",
         "prettier/prettier": "error",
         "no-console": "warn",
         "func-names": "off",

--- a/backend/.eslintrc.json
+++ b/backend/.eslintrc.json
@@ -9,6 +9,7 @@
         "jasmine": true
     },
     "rules": {
+        "dot-notation": "off",
         "prettier/prettier": "error",
         "no-console": "warn",
         "func-names": "off",

--- a/backend/Events/GameStateEvents/TrialStateChangeEvents.js
+++ b/backend/Events/GameStateEvents/TrialStateChangeEvents.js
@@ -41,7 +41,7 @@ function endTrial(io, socket, mafiaGame) {
 
     const playerChosen = room.voteHandler.getTrialVotedPlayer();
 
-    if (playerChosen && playerChosen !== 'abstain Vote') {
+    if (playerChosen && playerChosen !== 'noConfidence') {
         room.getPlayerByNickname(playerChosen).status = PlayerStatus.KILLED_BY_TOWN;
     }
 

--- a/backend/Events/GameStateEvents/TrialStateChangeEvents.js
+++ b/backend/Events/GameStateEvents/TrialStateChangeEvents.js
@@ -41,7 +41,7 @@ function endTrial(io, socket, mafiaGame) {
 
     const playerChosen = room.voteHandler.getTrialVotedPlayer();
 
-    if (playerChosen && playerChosen !== 'noConfidence') {
+    if (playerChosen && playerChosen !== 'no Confidence') {
         room.getPlayerByNickname(playerChosen).status = PlayerStatus.KILLED_BY_TOWN;
     }
 

--- a/backend/Events/VoteEvents.js
+++ b/backend/Events/VoteEvents.js
@@ -32,7 +32,7 @@ function voteTrial(io, socket, mafiaGame) {
         const voter = socket.player;
         const votee = voteForDTO.votingFor;
         room.voteHandler.trialVoteMap[voter.nickname] =
-            votee === 'abstain Vote' ? 'abstain Vote' : room.getPlayerByNickname(votee);
+            votee === 'noConfidence' ? 'noConfidence' : room.getPlayerByNickname(votee);
         io.in(socket.player.roomID).emit('trial-vote-update', new ListVoteDTO(room.voteHandler.trialVoteMap));
     });
 }

--- a/backend/Events/VoteEvents.js
+++ b/backend/Events/VoteEvents.js
@@ -32,7 +32,7 @@ function voteTrial(io, socket, mafiaGame) {
         const voter = socket.player;
         const votee = voteForDTO.votingFor;
         room.voteHandler.trialVoteMap[voter.nickname] =
-            votee === 'noConfidence' ? 'noConfidence' : room.getPlayerByNickname(votee);
+            votee === 'no Confidence' ? 'no Confidence' : room.getPlayerByNickname(votee);
         io.in(socket.player.roomID).emit('trial-vote-update', new ListVoteDTO(room.voteHandler.trialVoteMap));
     });
 }

--- a/backend/domain/DTO/response/ListVoteDTO.js
+++ b/backend/domain/DTO/response/ListVoteDTO.js
@@ -2,7 +2,7 @@ class ListVoteDTO {
     constructor(votes) {
         const nicknameVoteMap = {};
         for (const [voter, chosenPlayer] of Object.entries(votes)) {
-            nicknameVoteMap[voter] = chosenPlayer === 'abstain Vote' ? 'abstain Vote' : chosenPlayer.nickname;
+            nicknameVoteMap[voter] = chosenPlayer === 'noConfidence' ? 'noConfidence' : chosenPlayer.nickname;
         }
         this.voteMap = nicknameVoteMap;
     }

--- a/backend/domain/DTO/response/ListVoteDTO.js
+++ b/backend/domain/DTO/response/ListVoteDTO.js
@@ -2,7 +2,7 @@ class ListVoteDTO {
     constructor(votes) {
         const nicknameVoteMap = {};
         for (const [voter, chosenPlayer] of Object.entries(votes)) {
-            nicknameVoteMap[voter] = chosenPlayer === 'noConfidence' ? 'noConfidence' : chosenPlayer.nickname;
+            nicknameVoteMap[voter] = chosenPlayer === 'no Confidence' ? 'no Confidence' : chosenPlayer.nickname;
         }
         this.voteMap = nicknameVoteMap;
     }

--- a/backend/domain/VoteHandler.js
+++ b/backend/domain/VoteHandler.js
@@ -47,10 +47,10 @@ class VoteHandler {
     getVotedPlayer(voteMap, isTrial) {
         // Generate map of players who have been voted for, and the number of votes they have.
         const voteTally = {};
-        voteTally['abstain Vote'] = 0;
+        voteTally['noConfidence'] = 0;
         for (const [, chosenPlayer] of Object.entries(voteMap)) {
-            if (chosenPlayer === 'abstain Vote') {
-                voteTally['abstain Vote'] += 1;
+            if (chosenPlayer === 'noConfidence') {
+                voteTally['noConfidence'] += 1;
             } else if (Object.prototype.hasOwnProperty.call(voteTally, chosenPlayer.nickname)) {
                 voteTally[chosenPlayer.nickname] += 1;
             } else {
@@ -62,7 +62,7 @@ class VoteHandler {
         let maxVotes = 0;
         let votedPlayer = null;
         for (const [player, numVotes] of Object.entries(voteTally)) {
-            if (numVotes > maxVotes || (isTrial && player === 'abstain Vote' && numVotes === maxVotes)) {
+            if (numVotes > maxVotes || (isTrial && player === 'noConfidence' && numVotes === maxVotes)) {
                 maxVotes = numVotes;
                 votedPlayer = player;
             }

--- a/backend/domain/VoteHandler.js
+++ b/backend/domain/VoteHandler.js
@@ -47,10 +47,10 @@ class VoteHandler {
     getVotedPlayer(voteMap, isTrial) {
         // Generate map of players who have been voted for, and the number of votes they have.
         const voteTally = {};
-        voteTally['noConfidence'] = 0;
+        voteTally['no Confidence'] = 0;
         for (const [, chosenPlayer] of Object.entries(voteMap)) {
-            if (chosenPlayer === 'noConfidence') {
-                voteTally['noConfidence'] += 1;
+            if (chosenPlayer === 'no Confidence') {
+                voteTally['no Confidence'] += 1;
             } else if (Object.prototype.hasOwnProperty.call(voteTally, chosenPlayer.nickname)) {
                 voteTally[chosenPlayer.nickname] += 1;
             } else {
@@ -62,7 +62,7 @@ class VoteHandler {
         let maxVotes = 0;
         let votedPlayer = null;
         for (const [player, numVotes] of Object.entries(voteTally)) {
-            if (numVotes > maxVotes || (isTrial && player === 'noConfidence' && numVotes === maxVotes)) {
+            if (numVotes > maxVotes || (isTrial && player === 'no Confidence' && numVotes === maxVotes)) {
                 maxVotes = numVotes;
                 votedPlayer = player;
             }

--- a/backend/test/unit/TrialStateChangeEvents.unit.test.js
+++ b/backend/test/unit/TrialStateChangeEvents.unit.test.js
@@ -49,7 +49,7 @@ describe('trial-start unit tests', () => {
             expect(trialStartDTO.timeToVote).toBe(config.trial_total_vote_time_in_milliseconds);
         });
         clientSocket.on('trial-end', (trialEndDTO) => {
-            expect(trialEndDTO.playerKilled).toBe('abstain Vote');
+            expect(trialEndDTO.playerKilled).toBe('noConfidence');
             expect(trialEndDTO.isGameOver).toBe(false);
             done();
         });

--- a/backend/test/unit/TrialStateChangeEvents.unit.test.js
+++ b/backend/test/unit/TrialStateChangeEvents.unit.test.js
@@ -49,7 +49,7 @@ describe('trial-start unit tests', () => {
             expect(trialStartDTO.timeToVote).toBe(config.trial_total_vote_time_in_milliseconds);
         });
         clientSocket.on('trial-end', (trialEndDTO) => {
-            expect(trialEndDTO.playerKilled).toBe('noConfidence');
+            expect(trialEndDTO.playerKilled).toBe('no Confidence');
             expect(trialEndDTO.isGameOver).toBe(false);
             done();
         });

--- a/frontend/src/Components/Table.jsx
+++ b/frontend/src/Components/Table.jsx
@@ -138,7 +138,7 @@ export default function Table() {
     }
 
     function abstainHandler() {
-        socket.emit(`trial-vote`, { votingFor: `abstain Vote` });
+        socket.emit(`trial-vote`, { votingFor: `noConfidence` });
         dispatch({ type: 'show-selected', status: `Voted to Abstain` });
     }
 

--- a/frontend/src/Components/Table.jsx
+++ b/frontend/src/Components/Table.jsx
@@ -138,7 +138,7 @@ export default function Table() {
     }
 
     function abstainHandler() {
-        socket.emit(`trial-vote`, { votingFor: `noConfidence` });
+        socket.emit(`trial-vote`, { votingFor: `no Confidence` });
         dispatch({ type: 'show-selected', status: `Voted to Abstain` });
     }
 

--- a/frontend/src/Hooks/useGameState.js
+++ b/frontend/src/Hooks/useGameState.js
@@ -305,7 +305,7 @@ export default function useGameState() {
             dispatch({
                 type: 'trial-end',
                 status:
-                    playerKilled === 'abstain Vote' || !playerKilled
+                    playerKilled === 'noConfidence' || !playerKilled
                         ? `Nobody was killed in the Trial!`
                         : `The town voted to kill ${playerKilled}!`,
                 playerKilled,

--- a/frontend/src/Hooks/useGameState.js
+++ b/frontend/src/Hooks/useGameState.js
@@ -305,7 +305,7 @@ export default function useGameState() {
             dispatch({
                 type: 'trial-end',
                 status:
-                    playerKilled === 'noConfidence' || !playerKilled
+                    playerKilled === 'no Confidence' || !playerKilled
                         ? `Nobody was killed in the Trial!`
                         : `The town voted to kill ${playerKilled}!`,
                 playerKilled,


### PR DESCRIPTION
# Description
This PR fixes #[163]

This is specifically for a function called getVotedPlayer in VoteHandler.js.
noConfidence is a vote, whereas abstain means that a player has refused to vote at all. It would not appear as an entry in the voteMap. In this case, use noConfidence instead of abstain Vote.

# Demo
N/A

# Type of change:
(Delete the ones that are not relevant)
* Bugfix (Non-breaking change which fixes a bug)

# Checklist:
* Have you merged main into your branch?
* Have you tested your changes to ensure it works as expected and does not break existing functionality?
* If applicable, please ensure sufficient tests are added that is related to the changes.
* Please ensure this PR has a `label`, is linked to an `issue` and is related to a `project`
* If new documentation is required for this change, have you created a new documentation issue that describes the documentation needed? 