### PR TITLE
Closes #267: Removed logic from backend that caused jester to be considered mafia for detective votes

### DIFF
--- a/backend/Events/NightTimeVoteEvents.js
+++ b/backend/Events/NightTimeVoteEvents.js
@@ -38,7 +38,7 @@ exports.loadNightTimeEvents = (io, socket, mafiaGame) => {
         const suspect = room.getPlayerByNickname(detectiveVoteObj.votingFor);
         socket.emit(
             'suspect-reveal',
-            new SuspectRevealDTO(suspect.nickname, suspect.role === RoleEnum.MAFIA || suspect.role === RoleEnum.JESTER)
+            new SuspectRevealDTO(suspect.nickname, suspect.role === RoleEnum.MAFIA)
         );
     });
 };

--- a/backend/test/integration/NightTimeVoteEvents.integration.test.js
+++ b/backend/test/integration/NightTimeVoteEvents.integration.test.js
@@ -50,7 +50,7 @@ describe('night time vote event tests', () => {
         return new Promise((resolve) => {
             let isMafia = false;
             // check if host is mafia
-            if (hostRole === RoleEnum.JESTER || hostRole === RoleEnum.MAFIA) {
+            if (hostRole === RoleEnum.MAFIA) {
                 isMafia = true;
             }
             // check if receiving suspect reveal


### PR DESCRIPTION
# Description
This PR fixes #267

Removed logic in the `/backend/Events/NightTimeVoteEvents.js` logic to not consider jesters as mafia when responding to a vote request from a detective during the night.

Before: 
![image](https://user-images.githubusercontent.com/51986824/113783467-e6978180-9787-11eb-83c3-09860ff922e9.png)
![image](https://user-images.githubusercontent.com/51986824/113783505-f2834380-9787-11eb-809a-2fa9fb26d960.png)



After:
![image](https://user-images.githubusercontent.com/51986824/113783789-6887aa80-9788-11eb-8ad6-133020f3c42e.png)
![image](https://user-images.githubusercontent.com/51986824/113783814-72a9a900-9788-11eb-9899-085f7d0a4e5c.png)




# Type of change:
* Bug fix (Non-breaking change which fixes a bug)